### PR TITLE
[gatekeeperd] copy uid to local before passing to u_map

### DIFF
--- a/gatekeeperd/SoftGateKeeper.h
+++ b/gatekeeperd/SoftGateKeeper.h
@@ -25,8 +25,10 @@ extern "C" {
 #include <crypto_scrypt.h>
 }
 
+#include <base/memory.h>
 #include <UniquePtr.h>
 #include <gatekeeper/gatekeeper.h>
+
 #include <iostream>
 #include <unordered_map>
 
@@ -150,14 +152,15 @@ public:
     }
 
     bool DoVerify(const password_handle_t *expected_handle, const SizedBuffer &password) {
-        FastHashMap::const_iterator it = fast_hash_map_.find(expected_handle->user_id);
+        uint64_t user_id = android::base::get_unaligned(&expected_handle->user_id);
+        FastHashMap::const_iterator it = fast_hash_map_.find(user_id);
         if (it != fast_hash_map_.end() && VerifyFast(it->second, password)) {
             return true;
         } else {
             if (GateKeeper::DoVerify(expected_handle, password)) {
                 uint64_t salt;
                 GetRandom(&salt, sizeof(salt));
-                fast_hash_map_[expected_handle->user_id] = ComputeFastHash(password, salt);
+                fast_hash_map_[user_id] = ComputeFastHash(password, salt);
                 return true;
             }
         }

--- a/gatekeeperd/tests/Android.mk
+++ b/gatekeeperd/tests/Android.mk
@@ -20,7 +20,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := gatekeeperd-unit-tests
 LOCAL_ADDITIONAL_DEPENDENCIES := $(LOCAL_PATH)/Android.mk
 LOCAL_CFLAGS += -g -Wall -Werror -std=gnu++11 -Wno-missing-field-initializers
-LOCAL_SHARED_LIBRARIES := libgatekeeper libcrypto
+LOCAL_SHARED_LIBRARIES := libgatekeeper libcrypto libbase
 LOCAL_STATIC_LIBRARIES := libscrypt_static
 LOCAL_C_INCLUDES := external/scrypt/lib/crypto
 LOCAL_SRC_FILES := \


### PR DESCRIPTION
The compiler will issue the unaligned access instuctions
when reading from a packed struct. Since 'find' takes a
reference, if we pass the field directly it is removed
from its packed context and may be unreadable.

Read the field out directly from the packed struct and pass
in aligned to u_map to fix.

Bug: 22367550
Change-Id: Ia3b639c7518154ff5a2b7c233b752e154eab9aad
(cherry picked from commit 6e83dc4d325d68b568c841d3e88fda2a93e00663)